### PR TITLE
ci: update to test PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['7.4', '8.0']
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: ['7.4', '8.0', '8.1']
+        dependency-version: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This also updates to only test against the latest stable dependencies, which are what most people will use in production.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/gitea-php/blob/main/.github/CONTRIBUTING.md)** document.
