### PR TITLE
Adding getRawFile for repo

### DIFF
--- a/src/Api/Repo.php
+++ b/src/Api/Repo.php
@@ -112,6 +112,11 @@ class Repo extends AbstractApi
         ]);
     }
 
+    public function getRawFile(string $username, string $repository, string $filename, array $parameters = [])
+    {
+        return $this->get(sprintf('/repos/%s/%s/raw/%s', rawurlencode($username), rawurlencode($repository), rawurlencode($filename)), $parameters);
+    }
+
     public function issues(): Issue
     {
         return new Issue($this->getClient());

--- a/tests/Api/RepoTest.php
+++ b/tests/Api/RepoTest.php
@@ -259,3 +259,15 @@ it('should transfer a repository', function () {
 
     expect($api->transfer('owenvoke', 'gitea-php', 'other-account', ['1234', '4321']))->toBe($expectedArray);
 });
+
+it("should fetch a raw file's data", function () {
+    $expectedArray = ['# Gitea PHP'];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('get')
+        ->with('/repos/owenvoke/gitea-php/raw/README.md')
+        ->willReturn($expectedArray);
+
+    expect($api->show('owenvoke', 'gitea-php'))->toBe($expectedArray);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The API also allows to get raw file contents but the package did not include this. I've added this so the package allows to get raw file contents.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/gitea-php/blob/main/.github/CONTRIBUTING.md)** document.
