### PR TITLE
fix: resolve empty `Content-Type` error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ namespace OwenVoke\Gitea;
 
 use Http\Client\Common\HttpMethodsClientInterface;
 use Http\Client\Common\Plugin\AddHostPlugin;
+use Http\Client\Common\Plugin\ContentTypePlugin;
 use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Discovery\Psr17FactoryDiscovery;
@@ -68,8 +69,8 @@ final class Client
         $builder->addPlugin(new AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://gitea.com')));
         $builder->addPlugin(new HeaderDefaultsPlugin([
             'User-Agent' => 'gitea-php (https://github.com/owenvoke/gitea-php)',
-            'Content-Type' => 'application/json',
         ]));
+        $builder->addPlugin(new ContentTypePlugin());
 
         $this->apiVersion = $apiVersion ?: 'v1';
         $builder->addHeaderValue('Accept', 'application/json');

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,6 +68,7 @@ final class Client
         $builder->addPlugin(new AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://gitea.com')));
         $builder->addPlugin(new HeaderDefaultsPlugin([
             'User-Agent' => 'gitea-php (https://github.com/owenvoke/gitea-php)',
+            'Content-Type' => 'application/json',
         ]));
 
         $this->apiVersion = $apiVersion ?: 'v1';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This commit fixes an error when attempting to create an issue. https://docs.gitea.com/api/1.22/#tag/issue/operation/issueCreateIssue. If you try to send a request without the Content-Type header, the response will return an error: "[]: Empty Content-Type".

You can reproduce the error using this code.

```php
require_once __DIR__ . "/vendor/autoload.php";

use OwenVoke\Gitea\Client;

$client = new Client(null, null, 'https://host');
$client->authenticate('*****', null, Client::AUTH_ACCESS_TOKEN);
$response = $client->api('issues')->create(
    'test',
    'test',
    [
        'body' => 'test',
        'title' => 'test',
    ],
);

dd($response);
```

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/gitea-php/blob/main/.github/CONTRIBUTING.md)** document.
