### PR TITLE
feat: add support for repository contents

### DIFF
--- a/src/Api/Repo.php
+++ b/src/Api/Repo.php
@@ -3,6 +3,7 @@
 namespace OwenVoke\Gitea\Api;
 
 use OwenVoke\Gitea\Api\Repository\Commits;
+use OwenVoke\Gitea\Api\Repository\Contents;
 use OwenVoke\Gitea\Api\Repository\Stargazers;
 
 class Repo extends AbstractApi
@@ -120,6 +121,11 @@ class Repo extends AbstractApi
     public function commits(): Commits
     {
         return new Commits($this->getClient());
+    }
+
+    public function contents(): Contents
+    {
+        return new Contents($this->getClient());
     }
 
     public function stargazers(): Stargazers

--- a/src/Api/Repository/Contents.php
+++ b/src/Api/Repository/Contents.php
@@ -49,7 +49,14 @@ class Contents extends AbstractApi
         return $this->put(sprintf('/repos/%s/%s/contents/%s', rawurlencode($owner), rawurlencode($repository), rawurlencode($filepath)), $params);
     }
 
-    // create
+    public function create(string $owner, string $repository, string $filepath, array $params)
+    {
+        if (!isset($params['content'])) {
+            throw new MissingArgumentException(['content']);
+        }
+
+        return $this->post(sprintf('/repos/%s/%s/contents/%s', rawurlencode($owner), rawurlencode($repository), rawurlencode($filepath)), $params);
+    }
 
     // remove
 }

--- a/src/Api/Repository/Contents.php
+++ b/src/Api/Repository/Contents.php
@@ -3,6 +3,7 @@
 namespace OwenVoke\Gitea\Api\Repository;
 
 use OwenVoke\Gitea\Api\AbstractApi;
+use OwenVoke\Gitea\Exception\MissingArgumentException;
 
 class Contents extends AbstractApi
 {
@@ -14,5 +15,14 @@ class Contents extends AbstractApi
         }
 
         return $this->get(sprintf($format, rawurlencode($owner), rawurlencode($repository), rawurlencode($ref)));
+    }
+
+    public function create(string $owner, string $repository, array $parameters): array
+    {
+        if (! isset($parameters['files'])) {
+            throw new MissingArgumentException(['files']);
+        }
+
+        return $this->post(sprintf('/repos/%s/%s/contents', rawurlencode($owner), rawurlencode($repository)), $parameters);
     }
 }

--- a/src/Api/Repository/Contents.php
+++ b/src/Api/Repository/Contents.php
@@ -25,4 +25,14 @@ class Contents extends AbstractApi
 
         return $this->post(sprintf('/repos/%s/%s/contents', rawurlencode($owner), rawurlencode($repository)), $parameters);
     }
+
+    public function getFile(string $owner, string $repository, string $filepath, string $ref = ''): array
+    {
+        $format = '/repos/%s/%s/contents/%s';
+        if (!empty($ref)) {
+            $format = '/repos/%s/%s/contents/%s?ref=%s';
+        }
+
+        return $this->get(sprintf($format, rawurlencode($owner), rawurlencode($repository), rawurlencode($filepath), rawurlencode($ref)));
+    }
 }

--- a/src/Api/Repository/Contents.php
+++ b/src/Api/Repository/Contents.php
@@ -58,5 +58,12 @@ class Contents extends AbstractApi
         return $this->post(sprintf('/repos/%s/%s/contents/%s', rawurlencode($owner), rawurlencode($repository), rawurlencode($filepath)), $params);
     }
 
-    // remove
+    public function remove(string $owner, string $repository, string $filepath, array $params)
+    {
+        if (!isset($params['sha'])) {
+            throw new MissingArgumentException(['sha']);
+        }
+
+        return $this->delete(sprintf('/repos/%s/%s/contents/%s', rawurlencode($owner), rawurlencode($repository), rawurlencode($filepath)), $params);
+    }
 }

--- a/src/Api/Repository/Contents.php
+++ b/src/Api/Repository/Contents.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OwenVoke\Gitea\Api\Repository;
+
+use OwenVoke\Gitea\Api\AbstractApi;
+
+class Contents extends AbstractApi
+{
+    public function all(string $owner, string $repository, string $ref = ''): array
+    {
+        $format = '/repos/%s/%s/contents';
+        if (!empty($ref)) {
+            $format = '/repos/%s/%s/contents?ref=%s';
+        }
+
+        return $this->get(sprintf($format, rawurlencode($owner), rawurlencode($repository), rawurlencode($ref)));
+    }
+}

--- a/src/Api/Repository/Contents.php
+++ b/src/Api/Repository/Contents.php
@@ -10,7 +10,7 @@ class Contents extends AbstractApi
     public function all(string $owner, string $repository, string $ref = ''): array
     {
         $format = '/repos/%s/%s/contents';
-        if (!empty($ref)) {
+        if (! empty($ref)) {
             $format = '/repos/%s/%s/contents?ref=%s';
         }
 
@@ -29,7 +29,7 @@ class Contents extends AbstractApi
     public function show(string $owner, string $repository, string $filepath, string $ref = ''): array
     {
         $format = '/repos/%s/%s/contents/%s';
-        if (!empty($ref)) {
+        if (! empty($ref)) {
             $format = '/repos/%s/%s/contents/%s?ref=%s';
         }
 
@@ -38,11 +38,11 @@ class Contents extends AbstractApi
 
     public function update(string $owner, string $repository, string $filepath, array $params)
     {
-        if (!isset($params['content'])) {
+        if (! isset($params['content'])) {
             throw new MissingArgumentException(['content']);
         }
 
-        if (!isset($params['sha'])) {
+        if (! isset($params['sha'])) {
             throw new MissingArgumentException(['sha']);
         }
 
@@ -51,7 +51,7 @@ class Contents extends AbstractApi
 
     public function create(string $owner, string $repository, string $filepath, array $params)
     {
-        if (!isset($params['content'])) {
+        if (! isset($params['content'])) {
             throw new MissingArgumentException(['content']);
         }
 
@@ -60,7 +60,7 @@ class Contents extends AbstractApi
 
     public function remove(string $owner, string $repository, string $filepath, array $params)
     {
-        if (!isset($params['sha'])) {
+        if (! isset($params['sha'])) {
             throw new MissingArgumentException(['sha']);
         }
 

--- a/src/Api/Repository/Contents.php
+++ b/src/Api/Repository/Contents.php
@@ -17,7 +17,7 @@ class Contents extends AbstractApi
         return $this->get(sprintf($format, rawurlencode($owner), rawurlencode($repository), rawurlencode($ref)));
     }
 
-    public function create(string $owner, string $repository, array $parameters): array
+    public function bulkModify(string $owner, string $repository, array $parameters): array
     {
         if (! isset($parameters['files'])) {
             throw new MissingArgumentException(['files']);
@@ -26,7 +26,7 @@ class Contents extends AbstractApi
         return $this->post(sprintf('/repos/%s/%s/contents', rawurlencode($owner), rawurlencode($repository)), $parameters);
     }
 
-    public function getFile(string $owner, string $repository, string $filepath, string $ref = ''): array
+    public function show(string $owner, string $repository, string $filepath, string $ref = ''): array
     {
         $format = '/repos/%s/%s/contents/%s';
         if (!empty($ref)) {
@@ -35,4 +35,21 @@ class Contents extends AbstractApi
 
         return $this->get(sprintf($format, rawurlencode($owner), rawurlencode($repository), rawurlencode($filepath), rawurlencode($ref)));
     }
+
+    public function update(string $owner, string $repository, string $filepath, array $params)
+    {
+        if (!isset($params['content'])) {
+            throw new MissingArgumentException(['content']);
+        }
+
+        if (!isset($params['sha'])) {
+            throw new MissingArgumentException(['sha']);
+        }
+
+        return $this->put(sprintf('/repos/%s/%s/contents/%s', rawurlencode($owner), rawurlencode($repository), rawurlencode($filepath)), $params);
+    }
+
+    // create
+
+    // remove
 }

--- a/tests/Api/Repository/ContentsTest.php
+++ b/tests/Api/Repository/ContentsTest.php
@@ -42,14 +42,14 @@ it('should get files of the root dir for a repository by the ref', function () {
 });
 
 it('should modify files in repository without using the files option', function () {
-    $data = ['message' => 'modify files'];
+    $data = [];
 
     $api = $this->getApiMock();
     $api->expects($this->never())
         ->method('post')
         ->with('/repos/owenvoke/gitea-php/contents', $data);
 
-    $api->create('owenvoke', 'gitea-php', $data);
+    $api->bulkModify('owenvoke', 'gitea-php', $data);
 })->throws(MissingArgumentException::class);
 
 it('should modify files in repository using option files', function () {
@@ -62,7 +62,7 @@ it('should modify files in repository using option files', function () {
         ->with('/repos/owenvoke/gitea-php/contents', $data)
         ->willReturn($expectedValue);
 
-    expect($api->create('owenvoke', 'gitea-php', $data))->toBe($expectedValue);
+    expect($api->bulkModify('owenvoke', 'gitea-php', $data))->toBe($expectedValue);
 });
 
 it('should get file for a repository', function () {
@@ -78,7 +78,7 @@ it('should get file for a repository', function () {
         ->with('/repos/owenvoke/gitea-php/contents/content.txt')
         ->willReturn($expectedValue);
 
-    expect($api->getFile('owenvoke', 'gitea-php', 'content.txt'))->toBe($expectedValue);
+    expect($api->show('owenvoke', 'gitea-php', 'content.txt'))->toBe($expectedValue);
 });
 
 it('should get file for a repository by the ref', function () {
@@ -94,5 +94,47 @@ it('should get file for a repository by the ref', function () {
         ->with('/repos/owenvoke/gitea-php/contents/content.txt?ref=main')
         ->willReturn($expectedValue);
 
-    expect($api->getFile('owenvoke', 'gitea-php', 'content.txt', 'main'))->toBe($expectedValue);
+    expect($api->show('owenvoke', 'gitea-php', 'content.txt', 'main'))->toBe($expectedValue);
+});
+
+it('should update a file in the repository without using the content option', function () {
+    $data = [];
+
+    $api = $this->getApiMock();
+    $api->expects($this->never())
+        ->method('put')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt', $data);
+
+    $api->update('owenvoke', 'gitea-php', 'content.txt', $data);
+})->throws(MissingArgumentException::class);
+
+it('should update a file in the repository without using the sha option', function () {
+    $data = ['content' => ''];
+
+    $api = $this->getApiMock();
+    $api->expects($this->never())
+        ->method('put')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt', $data);
+
+    $api->update('owenvoke', 'gitea-php', 'content.txt', $data);
+})->throws(MissingArgumentException::class);
+
+it('should update a file in the repository', function () {
+    $expectedValue = [
+        'content' => [
+            '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
+            'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
+            'target' => '', 'type' => '', 'url' => ''
+        ]
+    ];
+
+    $data = ['content' => '', 'sha' => ''];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('put')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt')
+        ->willReturn($expectedValue);
+
+    expect($api->update('owenvoke', 'gitea-php', 'content.txt', $data))->toBe($expectedValue);
 });

--- a/tests/Api/Repository/ContentsTest.php
+++ b/tests/Api/Repository/ContentsTest.php
@@ -127,7 +127,6 @@ it('should update a file in the repository', function () {
             'target' => '', 'type' => '', 'url' => ''
         ]
     ];
-
     $data = ['content' => '', 'sha' => ''];
 
     $api = $this->getApiMock();
@@ -137,4 +136,34 @@ it('should update a file in the repository', function () {
         ->willReturn($expectedValue);
 
     expect($api->update('owenvoke', 'gitea-php', 'content.txt', $data))->toBe($expectedValue);
+});
+
+it('should create a file in the repository without using the content option', function () {
+    $data = [];
+
+    $api = $this->getApiMock();
+    $api->expects($this->never())
+        ->method('post')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt', $data);
+
+    $api->create('owenvoke', 'gitea-php', 'content.txt', $data);
+})->throws(MissingArgumentException::class);
+
+it('should create a file in the repository', function () {
+    $expectedValue = [
+        'content' => [
+            '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
+            'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
+            'target' => '', 'type' => '', 'url' => ''
+        ]
+    ];
+    $data = ['content' => ''];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('post')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt')
+        ->willReturn($expectedValue);
+
+    expect($api->create('owenvoke', 'gitea-php', 'content.txt', $data))->toBe($expectedValue);
 });

--- a/tests/Api/Repository/ContentsTest.php
+++ b/tests/Api/Repository/ContentsTest.php
@@ -5,7 +5,7 @@ use OwenVoke\Gitea\Exception\MissingArgumentException;
 
 beforeEach(fn () => $this->apiClass = Contents::class);
 
-it('should get metadata of all the entries of the root dir for a repository', function () {
+it('should get files of the root dir for a repository', function () {
     $expectedValue = [
         [
             '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
@@ -23,7 +23,7 @@ it('should get metadata of all the entries of the root dir for a repository', fu
     expect($api->all('owenvoke', 'gitea-php'))->toBe($expectedValue);
 });
 
-it('should get metadata of all the entries of the root dir for a repository by the ref', function () {
+it('should get files of the root dir for a repository by the ref', function () {
     $expectedValue = [
         [
             '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
@@ -53,7 +53,7 @@ it('should modify files in repository without using the files option', function 
 })->throws(MissingArgumentException::class);
 
 it('should modify files in repository using option files', function () {
-    $expectedValue = [];
+    $expectedValue = ['files' => []];
     $data = ['files' => []];
 
     $api = $this->getApiMock();
@@ -63,4 +63,36 @@ it('should modify files in repository using option files', function () {
         ->willReturn($expectedValue);
 
     expect($api->create('owenvoke', 'gitea-php', $data))->toBe($expectedValue);
+});
+
+it('should get file for a repository', function () {
+    $expectedValue = [
+        '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
+        'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
+        'target' => '', 'type' => '', 'url' => ''
+    ];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('get')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt')
+        ->willReturn($expectedValue);
+
+    expect($api->getFile('owenvoke', 'gitea-php', 'content.txt'))->toBe($expectedValue);
+});
+
+it('should get file for a repository by the ref', function () {
+    $expectedValue = [
+        '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
+        'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
+        'target' => '', 'type' => '', 'url' => ''
+    ];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('get')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt?ref=main')
+        ->willReturn($expectedValue);
+
+    expect($api->getFile('owenvoke', 'gitea-php', 'content.txt', 'main'))->toBe($expectedValue);
 });

--- a/tests/Api/Repository/ContentsTest.php
+++ b/tests/Api/Repository/ContentsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use OwenVoke\Gitea\Api\Repository\Contents;
+
+beforeEach(fn () => $this->apiClass = Contents::class);
+
+it('should get metadata of all the entries of the root dir for a repository', function () {
+    $expectedValue = [
+        [
+            '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
+            'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
+            'target' => '', 'type' => '', 'url' => ''
+        ]
+    ];
+
+    $api = $this->getApiMock();
+
+    $api->expects($this->once())
+        ->method('get')
+        ->with('/repos/owenvoke/gitea-php/contents')
+        ->willReturn($expectedValue);
+
+    expect($api->all('owenvoke', 'gitea-php'))->toBe($expectedValue);
+});
+
+it('should get metadata of all the entries of the root dir for a repository by the ref', function () {
+    $expectedValue = [
+        [
+            '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
+            'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
+            'target' => '', 'type' => '', 'url' => ''
+        ]
+    ];
+
+    $api = $this->getApiMock();
+
+    $api->expects($this->once())
+        ->method('get')
+        ->with('/repos/owenvoke/gitea-php/contents?ref=main')
+        ->willReturn($expectedValue);
+
+    expect($api->all('owenvoke', 'gitea-php', 'main'))->toBe($expectedValue);
+});

--- a/tests/Api/Repository/ContentsTest.php
+++ b/tests/Api/Repository/ContentsTest.php
@@ -167,3 +167,29 @@ it('should create a file in the repository', function () {
 
     expect($api->create('owenvoke', 'gitea-php', 'content.txt', $data))->toBe($expectedValue);
 });
+
+it('should remove a file in the repository without using the sha option', function () {
+    $data = [];
+
+    $api = $this->getApiMock();
+    $api->expects($this->never())
+        ->method('delete')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt', $data);
+
+    $api->remove('owenvoke', 'gitea-php', 'content.txt', $data);
+})->throws(MissingArgumentException::class);
+
+it('should remove a file in the repository', function () {
+    $expectedValue = [
+        'content' => null
+    ];
+    $data = ['sha' => ''];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('delete')
+        ->with('/repos/owenvoke/gitea-php/contents/content.txt')
+        ->willReturn($expectedValue);
+
+    expect($api->remove('owenvoke', 'gitea-php', 'content.txt', $data))->toBe($expectedValue);
+});

--- a/tests/Api/Repository/ContentsTest.php
+++ b/tests/Api/Repository/ContentsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use OwenVoke\Gitea\Api\Repository\Contents;
+use OwenVoke\Gitea\Exception\MissingArgumentException;
 
 beforeEach(fn () => $this->apiClass = Contents::class);
 
@@ -14,7 +15,6 @@ it('should get metadata of all the entries of the root dir for a repository', fu
     ];
 
     $api = $this->getApiMock();
-
     $api->expects($this->once())
         ->method('get')
         ->with('/repos/owenvoke/gitea-php/contents')
@@ -33,11 +33,34 @@ it('should get metadata of all the entries of the root dir for a repository by t
     ];
 
     $api = $this->getApiMock();
-
     $api->expects($this->once())
         ->method('get')
         ->with('/repos/owenvoke/gitea-php/contents?ref=main')
         ->willReturn($expectedValue);
 
     expect($api->all('owenvoke', 'gitea-php', 'main'))->toBe($expectedValue);
+});
+
+it('should modify files in repository without using the files option', function () {
+    $data = ['message' => 'modify files'];
+
+    $api = $this->getApiMock();
+    $api->expects($this->never())
+        ->method('post')
+        ->with('/repos/owenvoke/gitea-php/contents', $data);
+
+    $api->create('owenvoke', 'gitea-php', $data);
+})->throws(MissingArgumentException::class);
+
+it('should modify files in repository using option files', function () {
+    $expectedValue = [];
+    $data = ['files' => []];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('post')
+        ->with('/repos/owenvoke/gitea-php/contents', $data)
+        ->willReturn($expectedValue);
+
+    expect($api->create('owenvoke', 'gitea-php', $data))->toBe($expectedValue);
 });

--- a/tests/Api/Repository/ContentsTest.php
+++ b/tests/Api/Repository/ContentsTest.php
@@ -10,8 +10,8 @@ it('should get files of the root dir for a repository', function () {
         [
             '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
             'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
-            'target' => '', 'type' => '', 'url' => ''
-        ]
+            'target' => '', 'type' => '', 'url' => '',
+        ],
     ];
 
     $api = $this->getApiMock();
@@ -28,8 +28,8 @@ it('should get files of the root dir for a repository by the ref', function () {
         [
             '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
             'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
-            'target' => '', 'type' => '', 'url' => ''
-        ]
+            'target' => '', 'type' => '', 'url' => '',
+        ],
     ];
 
     $api = $this->getApiMock();
@@ -69,7 +69,7 @@ it('should get file for a repository', function () {
     $expectedValue = [
         '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
         'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
-        'target' => '', 'type' => '', 'url' => ''
+        'target' => '', 'type' => '', 'url' => '',
     ];
 
     $api = $this->getApiMock();
@@ -85,7 +85,7 @@ it('should get file for a repository by the ref', function () {
     $expectedValue = [
         '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
         'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
-        'target' => '', 'type' => '', 'url' => ''
+        'target' => '', 'type' => '', 'url' => '',
     ];
 
     $api = $this->getApiMock();
@@ -124,8 +124,8 @@ it('should update a file in the repository', function () {
         'content' => [
             '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
             'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
-            'target' => '', 'type' => '', 'url' => ''
-        ]
+            'target' => '', 'type' => '', 'url' => '',
+        ],
     ];
     $data = ['content' => '', 'sha' => ''];
 
@@ -154,8 +154,8 @@ it('should create a file in the repository', function () {
         'content' => [
             '_links' => [], 'content' => '', 'download_url' => '', 'encoding' => '', 'git_url' => '', 'html_url' => '',
             'last_commit_sha' => '', 'name' => '', 'path' => '', 'sha' => '', 'size' => 0, 'submodule_git_url' => '',
-            'target' => '', 'type' => '', 'url' => ''
-        ]
+            'target' => '', 'type' => '', 'url' => '',
+        ],
     ];
     $data = ['content' => ''];
 
@@ -181,7 +181,7 @@ it('should remove a file in the repository without using the sha option', functi
 
 it('should remove a file in the repository', function () {
     $expectedValue = [
-        'content' => null
+        'content' => null,
     ];
     $data = ['sha' => ''];
 


### PR DESCRIPTION
This pull request adds functionality for working with repository files. A detailed API description can be found at the following address: https://docs.gitea.com/api/1.23/#tag/repository/operation/repoCompareDiff.

...

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/gitea-php/blob/main/.github/CONTRIBUTING.md)** document.
