### PR TITLE
feat: add support for generating repos by templates

### DIFF
--- a/src/Api/Repo.php
+++ b/src/Api/Repo.php
@@ -47,6 +47,42 @@ class Repo extends AbstractApi
         return $this->post($path, $parameters);
     }
 
+    public function generate(
+        string $templateOwner,
+        string $templateName,
+        string $name,
+        string $organization,
+        string $description = '',
+        bool $public = true,
+        bool $avatar = true,
+        bool $labels = true,
+        bool $gitContent = true,
+        bool $gitHooks = true,
+        bool $protectedBranch = true,
+        bool $topics = true,
+        bool $webhooks = true,
+        ?string $defaultBranch = null
+    ): array {
+        $path = "/repos/{$templateOwner}/{$templateName}/generate";
+
+        $parameters = [
+            'name' => $name,
+            'owner' => $organization,
+            'private' => ! $public,
+            'description' => $description,
+            'avatar' => $avatar,
+            'default_branch' => $defaultBranch,
+            'git_content' => $gitContent,
+            'git_hooks' => $gitHooks,
+            'labels' => $labels,
+            'protected_branch' => $protectedBranch,
+            'topics' => $topics,
+            'webhooks' => $webhooks,
+        ];
+
+        return $this->post($path, $parameters);
+    }
+
     public function update(string $username, string $repository, array $values): array
     {
         return $this->patch(sprintf('/repos/%s/%s', rawurlencode($username), rawurlencode($repository)), $values);

--- a/tests/Api/RepoTest.php
+++ b/tests/Api/RepoTest.php
@@ -97,6 +97,36 @@ it('should create a repository with all parameters', function () {
     expect($api->create('repoName', 'test', 'https://voke.dev', false, null, 'MIT', '# Blah', null, 'MyLabels', true))->toBe($expectedArray);
 });
 
+it('should generate a repository only using its name', function () {
+    $expectedArray = ['id' => 1, 'name' => 'repoName'];
+
+    $api = $this->getApiMock();
+    $api->expects($this->once())
+        ->method('post')
+        ->with('/repos/FakeOwner/TemplateRepo/generate', [
+            'name' => 'NewRepo',
+            'description' => '',
+            'private' => false,
+            'owner' => 'me',
+            'avatar' => true,
+            'default_branch' => null,
+            'git_content' => true,
+            'git_hooks' => true,
+            'labels' => true,
+            'protected_branch' => true,
+            'topics' => true,
+            'webhooks' => true,
+        ])
+        ->willReturn($expectedArray);
+
+    expect($api->generate(
+        templateOwner: 'FakeOwner',
+        templateName: 'TemplateRepo',
+        name: 'NewRepo',
+        organization: 'me',
+    ))->toBe($expectedArray);
+});
+
 it('should get the subscribers for a repository', function () {
     $expectedArray = [['id' => 1, 'username' => 'owenvoke']];
 


### PR DESCRIPTION
Support for generating repositories from template repositories.

More about template repositories: https://docs.gitea.com/usage/template-repositories
More about the API endpoint: https://docs.gitea.com/api/1.20/#tag/repository/operation/generateRepo

...

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/gitea-php/blob/main/.github/CONTRIBUTING.md)** document.
